### PR TITLE
feat: Add Rc, RefCell, and Combined smart pointer exercises #3

### DIFF
--- a/katas/02-structure/01-smart-pointers/README.md
+++ b/katas/02-structure/01-smart-pointers/README.md
@@ -104,6 +104,25 @@ Master the basics of smart pointers in Rust
 
 Resolved exercises : [solutions](solutions/main.rs)
 
+---
+
+### ❓ FAQ: Rust Myths vs Reality
+
+Below are some common misconceptions (“myths”) about Rust, contrasted with what actually happens in practice — many illustrated by the smart‑pointer exercises in this kata.
+
+| Myth                                                        | Reality                                                                                                                                         | Related Exercises                                  |
+|-------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------|
+| **"Rust has zero memory bugs, always."**                    | Rust prevents many memory errors at compile time, but you can still create logic bugs, runtime panics (`RefCell` borrow violations), or leaks. | Combined Ex. 1 (leak), Combined Ex. 3 (RefCell panic) |
+| **"Rust cannot leak memory."**                              | Strong `Rc` cycles never drop to zero → leaked allocations. Rust has no GC to detect or collect them.                                           | Combined Ex. 1; Rc section Ex. 1 (shared tails)    |
+| **"You don't need smart pointers in Rust."**                | Smart pointers are central to building recursive, shared, or mutable shared data structures.                                                    | All sections                                       |
+| **"Rust forbids all shared mutability."**                   | It forbids unsafe shared mutability statically; you can opt into interior mutability via `RefCell`, `Mutex`, etc.                              | RefCell Ex. 1–3; Combined Ex. 3                    |
+| **"`Rc<RefCell<_>` is always safe."**                       | It’s flexible but shifts borrow checks to runtime; misuse leads to panics. Use carefully and document invariants.                              | RefCell Ex. 2–3; Combined Ex. 3                    |
+| **"Rust code is too rigid for graphs and complex structures."** | Use `Rc`, `Weak`, and `RefCell` to model DAGs, graphs, and shared trees safely (with care).                                                     | Rc Ex. 2; Combined Ex. 2                           |
+| **"Avoiding `unsafe` means you can’t get into trouble."**   | You can still leak memory, panic, or deadlock using only safe abstractions incorrectly.                                                         | Combined Ex. 1 & 3                                 |
+| **"Rust never panics unless you call `panic!()`."**         | Many standard types (like `RefCell`) panic on contract violations (e.g. double mutable borrow).                                                 | RefCell Ex. 1–3; Combined Ex. 3                    |
+
+---
+
 ## How to run a kata
 All katas share the same structure:
 ```

--- a/katas/02-structure/01-smart-pointers/solutions/combined.rs
+++ b/katas/02-structure/01-smart-pointers/solutions/combined.rs
@@ -1,0 +1,101 @@
+/**
+ * Section 4 : Rc + RefCell Combined
+ * 
+ * - *Exercise 1:* Implement a bidirectional `Person` struct using `Rc<RefCell<T>>`.
+ *     - Each `Person` has a name and an optional `friend`.
+ *     - Use `Rc<RefCell<Person>>` to allow two persons to point to each other.
+ *     - This creates a cycle: explain how and why it causes a memory leak.
+ *
+ * - *Exercise 2:* Create a mutable `GraphNode` struct.
+ *     - Each node has a value and a list of neighbors (`Vec<Rc<RefCell<GraphNode>>>`).
+ *     - Implement a method to connect two nodes.
+ *     - Use `Weak` references to break cycles and prevent memory leaks.
+ *
+ * - *Exercise 3:* Build a trick example showing how `RefCell` can panic at runtime.
+ *     - Create a struct that borrows mutably twice via `RefCell`, triggering a panic.
+ *     - Show that Rust's borrow checker doesn't catch it at compile time.
+ *
+ * These exercises show both the power and the pitfalls of combining Rc and RefCell in Rust.
+ */
+
+ use std::cell::RefCell;
+ use std::rc::{Rc, Weak};
+ use std::panic;
+ 
+ 
+ // Section 4 : Rc + RefCell Combined - Exercise 1
+ 
+ #[derive(Debug)]
+ pub struct Person {
+     pub name: String,
+     pub friend: RefCell<Option<Rc<Person>>>,
+ }
+ 
+ impl Person {
+     pub fn new(name: &str) -> Rc<Self> {
+         Rc::new(Person {
+             name: name.to_string(),
+             friend: RefCell::new(None),
+         })
+     }
+ 
+     pub fn befriend(a: &Rc<Person>, b: &Rc<Person>) {
+         *a.friend.borrow_mut() = Some(Rc::clone(b));
+         *b.friend.borrow_mut() = Some(Rc::clone(a));
+     }
+ }
+ 
+ // Section 4 : Rc + RefCell Combined - Exercise 2
+ 
+ #[derive(Debug)]
+ pub struct GraphNode {
+     pub name: String,
+     pub neighbors: RefCell<Vec<Weak<GraphNode>>>,
+ }
+ 
+ impl GraphNode {
+     pub fn new(name: &str) -> Rc<Self> {
+         Rc::new(GraphNode {
+             name: name.to_string(),
+             neighbors: RefCell::new(vec![]),
+         })
+     }
+ 
+     pub fn connect(a: &Rc<Self>, b: &Rc<Self>) {
+         a.neighbors.borrow_mut().push(Rc::downgrade(b));
+         b.neighbors.borrow_mut().push(Rc::downgrade(a));
+     }
+ 
+     pub fn print_neighbors(&self) {
+         for weak in self.neighbors.borrow().iter() {
+             if let Some(neigh) = weak.upgrade() {
+                 println!("{} is connected to {}", self.name, neigh.name);
+             }
+         }
+     }
+ }
+ 
+ // Section 4 : Rc + RefCell Combined - Exercise 3
+ 
+ pub struct Trap {
+     value: RefCell<i32>,
+ }
+ 
+ impl Trap {
+     pub fn new(x: i32) -> Self {
+         Trap {
+             value: RefCell::new(x),
+         }
+     }
+ 
+     pub fn double_mut_borrow(&self) {
+         let _first = self.value.borrow_mut();
+         let _second = self.value.borrow_mut(); // PANIC at the execution
+     }
+ }
+ 
+ pub fn run_trap() {
+     let trap = Trap::new(10);
+     // This will crash the program with a panic, but that's the point
+     trap.double_mut_borrow();
+ }

--- a/katas/02-structure/01-smart-pointers/solutions/main.rs
+++ b/katas/02-structure/01-smart-pointers/solutions/main.rs
@@ -1,4 +1,8 @@
 use crate::r#box::{List, TreeNode, MyRc};
+use crate::rc::{RcList, TreeNode1}
+use crate::refcell::TreeNode2
+use crate::combined::{Person, GraphNode, Trap, run_trap};
+use std::rc::Rc;
 
 mod r#box;
 mod rc;
@@ -6,7 +10,9 @@ mod refcell;
 mod combined;
 
 fn main() {
+    
     // Section 1: Box Smart Pointers - Exercise 1
+    
     let list = List::new()
         .prepend(3)
         .prepend(2)
@@ -15,6 +21,7 @@ fn main() {
     list.print(); // Output: 1 -> 2 -> 3 -> Nil
 
     // Section 1: Box Smart Pointers - Exercise 2
+    
     let tree = Box::new(TreeNode::new(5))
         .insert(3)
         .insert(7)
@@ -24,6 +31,7 @@ fn main() {
     tree.print_inorder(); // Expected output (sorted): 1 3 4 5 7
 
     // Section 1: Box Smart Pointers - Exercise 3
+
     let x = MyRc::new(42);
     println!("Count: {}", x.count());
 
@@ -31,4 +39,102 @@ fn main() {
     println!("Count: {}", y.count());
 
     println!("Value in y: {}", y.get());
+
+    // Section 2 : Rc & Shared Ownership - Exercise 1
+
+    let shared_tail = Rc::new(RcList::Cons(10, Rc::new(RcList::Cons(20, Rc::new(RcList::Nil)))));
+
+    let list1 = RcList::Cons(1, Rc::clone(&shared_tail));
+    let list2 = RcList::Cons(2, Rc::clone(&shared_tail));
+
+    list1.print(); // 1 -> 10 -> 20 -> Nil
+    list2.print(); // 2 -> 10 -> 20 -> Nil
+
+    // Section 2 : Rc & Shared Ownership - Exercise 2
+
+    let shared_leaf = Rc::new(TreeNode1::new(42));
+
+    let left = Rc::new(TreeNode1::with_children(1, Some(Rc::clone(&shared_leaf)), None));
+    let right = Rc::new(TreeNode1::with_children(2, None, Some(Rc::clone(&shared_leaf))));
+
+    let root = Rc::new(TreeNode1::with_children(0, Some(left), Some(right)));
+
+    TreeNode1::print_inorder(Some(&root)); // Output: 42 1 0 2 42
+
+    // Section 2 : Rc & Shared Ownership - Exercise 3
+
+    rc::demo_rc_counts();
+
+    // Section 3 RefCell & Interior Mutability - Exercise 1
+
+    let counter = refcell::Counter::new(0);
+    counter.increment();
+    counter.increment();
+    println!("Counter: {}", counter.get()); // 2
+    counter.reset();
+    println!("Counter after reset: {}", counter.get()); // 0
+
+    // Section 3 RefCell & Interior Mutability - Exercise 2
+
+    let logger = refcell::SharedLog::new();
+    let logger_clone = Rc::clone(&logger);
+    logger.log("App started");
+    logger_clone.log("User logged in");
+    logger.show();
+
+    // Section 3 RefCell & Interior Mutability - Exercise 3
+
+    let shared_leaf = TreeNode2::new(99);
+
+    let left = TreeNode2::new(1);
+    TreeNode2::set_left(&left, Rc::clone(&shared_leaf));
+
+    let right = TreeNode2::new(2);
+    TreeNode2::set_right(&right, Rc::clone(&shared_leaf));
+
+    let root = TreeNode2::new(0);
+    TreeNode2::set_left(&root, left);
+    TreeNode2::set_right(&root, right);
+
+    TreeNode2::print_inorder(Some(root)); // 99 1 0 2 99
+
+    // Section 4 : Rc + RefCell Combined - Exercise 1
+
+    let alice = Person::new("Alice");
+    let bob = Person::new("Bob");
+
+    // Create a mutual reference cycle between Alice and Bob
+    Person::befriend(&alice, &bob);
+
+    println!("Alice's friend: {:?}", alice.friend.borrow().as_ref().map(|p| &p.name));
+    println!("Bob's friend: {:?}", bob.friend.borrow().as_ref().map(|p| &p.name));
+
+    // Show strong reference counts (they stay >1 due to the cycle)
+    println!("Alice strong count: {}", Rc::strong_count(&alice));
+    println!("Bob strong count: {}", Rc::strong_count(&bob));
+
+    // Even when main ends, these objects will never be freed (memory leak)
+
+    // Section 4 : Rc + RefCell Combined - Exercise 2
+
+    let node_a = GraphNode::new("A");
+    let node_b = GraphNode::new("B");
+    let node_c = GraphNode::new("C");
+
+    // Connect nodes bidirectionally using Weak references to prevent cycles
+    GraphNode::connect(&node_a, &node_b);
+    GraphNode::connect(&node_b, &node_c);
+    GraphNode::connect(&node_c, &node_a);
+
+    // Print neighbors of each node
+    node_a.print_neighbors();
+    node_b.print_neighbors();
+    node_c.print_neighbors();
+
+    // Section 4 : Rc + RefCell Combined - Exercise 3
+
+    println!("Attempting to trigger a RefCell panic...");
+
+    // This will panic due to double mutable borrow
+    combined::run_trap();
 }

--- a/katas/02-structure/01-smart-pointers/solutions/rc.rs
+++ b/katas/02-structure/01-smart-pointers/solutions/rc.rs
@@ -1,0 +1,95 @@
+/**
+ * Section 2 : Rc & Shared Ownership
+ * 
+ * - *Exercise 1:* Define an enum `RcList` to implement a singly linked list of integers.
+ *     - Use `Rc` to enable shared ownership of list tails.
+ *     - Create multiple lists that share the same suffix.
+ *     - Implement a method `print` to display the list in order (e.g., 1 -> 2 -> 3 -> Nil).
+ *
+ * - *Exercise 2:* Create a struct `TreeNode1` representing a binary tree of integers.
+ *     - Use `Rc` for left and right children to allow subtree sharing.
+ *     - Implement a `print_inorder` method to display values in sorted order.
+ *     - Demonstrate shared subtrees by cloning shared nodes.
+ *
+ * - *Exercise 3:* Demonstrate reference counting with `Rc<T>`.
+ *     - Track how many references exist using `Rc::strong_count`.
+ *     - Clone an `Rc` multiple times and print the reference count at each step.
+ *     - Show how scope impacts the count and automatic deallocation.
+ *
+ * Define in this module the types, methods, and functions, and use them in `main.rs`.
+ * The exercises in this coding dojo are designed to explore real use-cases for Rc in Rust.
+ */
+
+use std::rc::Rc;
+
+// Section 2 : Rc & Shared Ownership - Exercise 1
+
+pub enum RcList {
+    Cons(i32, Rc<RcList>),
+    Nil,
+}
+
+impl RcList {
+    pub fn print(&self) {
+        match self {
+            RcList::Cons(val, next) => {
+                print!("{} -> ", val);
+                next.print();
+            }
+            RcList::Nil => {
+                println!("Nil");
+            }
+        }
+    }
+}
+
+// Section 2 : Rc & Shared Ownership - Exercise 2
+
+#[derive(Debug)]
+pub struct TreeNode1 {
+    pub value: i32,
+    pub left: Option<Rc<TreeNode1>,
+    pub right: Option<Rc<TreeNode1>>,
+}
+
+impl TreeNode1 {
+    pub fn new(value: i32) -> Self {
+        TreeNode1 {
+            value,
+            left: None,
+            right: None,
+        }
+    }
+
+    pub fn with_children(value: i32, left: Option<Rc<TreeNode1>>, right: Option<Rc<TreeNode1>>) -> Self {
+        TreeNode1 { value, left, right }
+    }
+
+    pub fn print_inorder(node: Option<&Rc<TreeNode1>>) {
+        if let Some(n) = node {
+            Self::print_inorder(n.left.as_ref());
+            print!("{} ", n.value);
+            Self::print_inorder(n.right.as_ref());
+        }
+    }
+}
+
+// Section 2 : Rc & Shared Ownership - Exercise 3
+
+pub fn demo_rc_counts() {
+    let data = Rc::new(vec![1, 2, 3]);
+
+    println!("Initial count: {}", Rc::strong_count(&data)); // 1
+
+    let data_clone1 = Rc::clone(&data);
+    println!("After clone 1: {}", Rc::strong_count(&data)); // 2
+
+    {
+        let data_clone2 = Rc::clone(&data);
+        println!("Inside inner scope: {}", Rc::strong_count(&data)); // 3
+        println!("data_clone2: {:?}", data_clone2);
+    }
+
+    println!("After inner scope: {}", Rc::strong_count(&data)); // 2
+    println!("data_clone1: {:?}", data_clone1);
+}

--- a/katas/02-structure/01-smart-pointers/solutions/refcell.rs
+++ b/katas/02-structure/01-smart-pointers/solutions/refcell.rs
@@ -1,0 +1,110 @@
+/**
+ * Section 3 : RefCell & Interior Mutability
+ * 
+ * - *Exercise 1:* Define a struct `Counter` that wraps an integer inside a `RefCell<i32>`.
+ *     - Implement methods `increment`, `get`, and `reset`.
+ *     - Demonstrate how interior mutability allows mutation through an immutable reference.
+ *
+ * - *Exercise 2:* Create a struct `SharedLog` with a `RefCell<Vec<String>>` to simulate logging.
+ *     - Use `Rc<SharedLog>` to allow multiple components to push logs into the same buffer.
+ *     - Implement a `log(&self, msg: &str)` method that appends to the log.
+ *     - Implement a `show(&self)` method to display the log.
+ *
+ * - *Exercise 3:* Build a mutable tree structure using `Rc<RefCell<TreeNode2>>`.
+ *     - Each node holds a value and optional mutable children (`left`, `right`).
+ *     - Implement methods to create nodes, attach children, and print the tree in-order.
+ *     - Demonstrate that nodes can be modified from multiple owners thanks to `RefCell`.
+ *
+ * Define in this module the types, methods, and functions, and use them in `main.rs`.
+ * The exercises in this coding dojo are designed to explore real use-cases for RefCell in Rust.
+ */
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+// Section 3 RefCell & Interior Mutability - Exercise 1
+
+pub struct Counter {
+    value: RefCell<i32>,
+}
+
+impl Counter {
+    pub fn new(initial: i32) -> Self {
+        Counter {
+            value: RefCell::new(initial),
+        }
+    }
+
+    pub fn increment(&self) {
+        *self.value.borrow_mut() += 1;
+    }
+
+    pub fn reset(&self) {
+        *self.value.borrow_mut() = 0;
+    }
+
+    pub fn get(&self) -> i32 {
+        *self.value.borrow()
+    }
+}
+
+// Section 3 RefCell & Interior Mutability - Exercise 2
+
+pub struct SharedLog {
+    messages: RefCell<Vec<String>>,
+}
+
+impl SharedLog {
+    pub fn new() -> Rc<Self> {
+        Rc::new(SharedLog {
+            messages: RefCell::new(Vec::new()),
+        })
+    }
+
+    pub fn log(&self, msg: &str) {
+        self.messages.borrow_mut().push(msg.to_string());
+    }
+
+    pub fn show(&self) {
+        for msg in self.messages.borrow().iter() {
+            println!("- {}", msg);
+        }
+    }
+}
+
+
+// Section 3 RefCell & Interior Mutability - Exercise 3
+
+#[derive(Debug)]
+pub struct TreeNode2 {
+    pub value: i32,
+    pub left: Option<Rc<RefCell<TreeNode2>>>,
+    pub right: Option<Rc<RefCell<TreeNode2>>>,
+}
+
+impl TreeNode2 {
+    pub fn new(value: i32) -> Rc<RefCell<Self>> {
+        Rc::new(RefCell::new(TreeNode2 {
+            value,
+            left: None,
+            right: None,
+        }))
+    }
+
+    pub fn set_left(parent: &Rc<RefCell<TreeNode2>>, child: Rc<RefCell<TreeNode2>>) {
+        parent.borrow_mut().left = Some(child);
+    }
+
+    pub fn set_right(parent: &Rc<RefCell<TreeNode2>>, child: Rc<RefCell<TreeNode2>>) {
+        parent.borrow_mut().right = Some(child);
+    }
+
+    pub fn print_inorder(node: Option<Rc<RefCell<TreeNode2>>>) {
+        if let Some(rc_node) = node {
+            let node_ref = rc_node.borrow();
+            Self::print_inorder(node_ref.left.clone());
+            print!("{} ", node_ref.value);
+            Self::print_inorder(node_ref.right.clone());
+        }
+    }
+}

--- a/katas/02-structure/01-smart-pointers/src/combined.rs
+++ b/katas/02-structure/01-smart-pointers/src/combined.rs
@@ -1,0 +1,19 @@
+/**
+ * Section 4 : Rc + RefCell Combined
+ * 
+ * - *Exercise 1:* Implement a bidirectional `Person` struct using `Rc<RefCell<T>>`.
+ *     - Each `Person` has a name and an optional `friend`.
+ *     - Use `Rc<RefCell<Person>>` to allow two persons to point to each other.
+ *     - This creates a cycle: explain how and why it causes a memory leak.
+ *
+ * - *Exercise 2:* Create a mutable `GraphNode` struct.
+ *     - Each node has a value and a list of neighbors (`Vec<Rc<RefCell<GraphNode>>>`).
+ *     - Implement a method to connect two nodes.
+ *     - Use `Weak` references to break cycles and prevent memory leaks.
+ *
+ * - *Exercise 3:* Build a trick example showing how `RefCell` can panic at runtime.
+ *     - Create a struct that borrows mutably twice via `RefCell`, triggering a panic.
+ *     - Show that Rust's borrow checker doesn't catch it at compile time.
+ *
+ * These exercises show both the power and the pitfalls of combining Rc and RefCell in Rust.
+ */

--- a/katas/02-structure/01-smart-pointers/src/rc.rs
+++ b/katas/02-structure/01-smart-pointers/src/rc.rs
@@ -1,0 +1,21 @@
+/**
+ * Section 2 : Rc & Shared Ownership
+ * 
+ * - *Exercise 1:* Define an enum `RcList` to implement a singly linked list of integers.
+ *     - Use `Rc` to enable shared ownership of list tails.
+ *     - Create multiple lists that share the same suffix.
+ *     - Implement a method `print` to display the list in order (e.g., 1 -> 2 -> 3 -> Nil).
+ *
+ * - *Exercise 2:* Create a struct `TreeNode1` representing a binary tree of integers.
+ *     - Use `Rc` for left and right children to allow subtree sharing.
+ *     - Implement a `print_inorder` method to display values in sorted order.
+ *     - Demonstrate shared subtrees by cloning shared nodes.
+ *
+ * - *Exercise 3:* Demonstrate reference counting with `Rc<T>`.
+ *     - Track how many references exist using `Rc::strong_count`.
+ *     - Clone an `Rc` multiple times and print the reference count at each step.
+ *     - Show how scope impacts the count and automatic deallocation.
+ *
+ * Define in this module the types, methods, and functions, and use them in `main.rs`.
+ * The exercises in this coding dojo are designed to explore real use-cases for Rc in Rust.
+ */

--- a/katas/02-structure/01-smart-pointers/src/refcell.rs
+++ b/katas/02-structure/01-smart-pointers/src/refcell.rs
@@ -1,0 +1,20 @@
+/**
+ * Section 3 : RefCell & Interior Mutability
+ * 
+ * - *Exercise 1:* Define a struct `Counter` that wraps an integer inside a `RefCell<i32>`.
+ *     - Implement methods `increment`, `get`, and `reset`.
+ *     - Demonstrate how interior mutability allows mutation through an immutable reference.
+ *
+ * - *Exercise 2:* Create a struct `SharedLog` with a `RefCell<Vec<String>>` to simulate logging.
+ *     - Use `Rc<SharedLog>` to allow multiple components to push logs into the same buffer.
+ *     - Implement a `log(&self, msg: &str)` method that appends to the log.
+ *     - Implement a `show(&self)` method to display the log.
+ *
+ * - *Exercise 3:* Build a mutable tree structure using `Rc<RefCell<TreeNode2>>`.
+ *     - Each node holds a value and optional mutable children (`left`, `right`).
+ *     - Implement methods to create nodes, attach children, and print the tree in-order.
+ *     - Demonstrate that nodes can be modified from multiple owners thanks to `RefCell`.
+ *
+ * Define in this module the types, methods, and functions, and use them in `main.rs`.
+ * The exercises in this coding dojo are designed to explore real use-cases for RefCell in Rust.
+ */


### PR DESCRIPTION
### Description

This PR extends the Smart Pointers kata by adding new sections focused on:

- `Rc<T>` – shared ownership and reference counting
- `RefCell<T>` – interior mutability and dynamic borrow checks
- Combined usage of `Rc<RefCell<T>>` – highlighting memory leaks, safe graph modeling, and runtime panics

### Other changes

- Added a **FAQ section** to the `README.md` of this kata :  
  Clarifies common misconceptions about Rust memory safety, borrow checking, and smart pointers

### Notes

This continues the Smart Pointers module started in #2. 

A future PR will introduce exercises on threading and concurrency (e.g., `Arc`, `Mutex`, `Send`, `Sync`, etc.), to complement this module.
