### PR TITLE
fix: translate remaining FR strings to English

### DIFF
--- a/academy/src/data/gamification.ts
+++ b/academy/src/data/gamification.ts
@@ -1,38 +1,38 @@
 import type { Badge, Quest, SkillNode } from '../types'
 
 export const BADGES: Badge[] = [
-  { id: 'borrow-checker', icon: '🛡️', name: 'Borrow Checker', description: 'Complète 5 katas d\'ownership', unlocked: true, color: '#3d9bff', glowColor: 'rgba(61,155,255,.35)' },
-  { id: 'no-panic', icon: '🚫', name: 'No Panic!', description: 'Complète 3 katas sans utiliser unwrap()', unlocked: true, color: '#34c46e', glowColor: 'rgba(74,222,128,.35)' },
-  { id: 'zero-cost', icon: '⚡', name: 'Zero-Cost', description: 'Résous un kata sans aucune allocation', unlocked: true, color: '#f0a830', glowColor: 'rgba(255,194,75,.3)' },
-  { id: 'lifetime-master', icon: '⏳', name: 'Lifetime Master', description: 'Maîtrise les annotations de lifetime', unlocked: false, color: '#7c5cf0', glowColor: 'rgba(124,92,240,.3)' },
-  { id: 'trait-wizard', icon: '🧙', name: 'Trait Wizard', description: 'Implémente 5 traits différents', unlocked: false, color: '#e040fb', glowColor: 'rgba(224,64,251,.25)' },
-  { id: 'ferrous', icon: '🦀', name: 'Ferrous', description: 'Atteins le niveau 10', unlocked: false, color: '#e0552a', glowColor: 'rgba(224,85,42,.3)' }
+  { id: 'borrow-checker', icon: '🛡️', name: 'Borrow Checker', description: 'Complete 5 ownership katas', unlocked: true, color: '#3d9bff', glowColor: 'rgba(61,155,255,.35)' },
+  { id: 'no-panic', icon: '🚫', name: 'No Panic!', description: 'Complete 3 katas without using unwrap()', unlocked: true, color: '#34c46e', glowColor: 'rgba(74,222,128,.35)' },
+  { id: 'zero-cost', icon: '⚡', name: 'Zero-Cost', description: 'Solve a kata without any allocation', unlocked: true, color: '#f0a830', glowColor: 'rgba(255,194,75,.3)' },
+  { id: 'lifetime-master', icon: '⏳', name: 'Lifetime Master', description: 'Master lifetime annotations', unlocked: false, color: '#7c5cf0', glowColor: 'rgba(124,92,240,.3)' },
+  { id: 'trait-wizard', icon: '🧙', name: 'Trait Wizard', description: 'Implement 5 different traits', unlocked: false, color: '#e040fb', glowColor: 'rgba(224,64,251,.25)' },
+  { id: 'ferrous', icon: '🦀', name: 'Ferrous', description: 'Reach level 10', unlocked: false, color: '#e0552a', glowColor: 'rgba(224,85,42,.3)' }
 ]
 
 export const QUESTS: Quest[] = [
-  { id: 'no-clone-3', title: 'Zero Clone', description: 'Résous 1 kata sans .clone()', xpReward: 120, progress: 0, target: 1, completed: false },
-  { id: 'lifetime-5', title: 'Time Lord', description: 'Corrige les lifetime errors', xpReward: 200, progress: 0, target: 1, completed: false },
-  { id: 'streak-7', title: 'Acier trempé', description: '7 jours consécutifs', xpReward: 150, progress: 7, target: 7, completed: true },
-  { id: 'own-full', title: 'Maître Propriétaire', description: 'Complète le kata Ownership', xpReward: 300, progress: 0, target: 1, completed: false }
+  { id: 'no-clone-3', title: 'Zero Clone', description: 'Solve 1 kata without .clone()', xpReward: 120, progress: 0, target: 1, completed: false },
+  { id: 'lifetime-5', title: 'Time Lord', description: 'Fix the lifetime errors', xpReward: 200, progress: 0, target: 1, completed: false },
+  { id: 'streak-7', title: 'Tempered Steel', description: '7 consecutive days', xpReward: 150, progress: 7, target: 7, completed: true },
+  { id: 'own-full', title: 'Ownership Master', description: 'Complete the Ownership kata', xpReward: 300, progress: 0, target: 1, completed: false }
 ]
 
 export const SKILL_NODES: SkillNode[] = [
-  { id: 'bases', name: 'Les bases', icon: '⚙️', unlocked: true, katasCompleted: 3, katasTotal: 3, x: 420, y: 12, size: 93, color: '#3d9bff', description: "Variables, types, fonctions et contrôle de flux. Les fondations avant de plonger dans l'ownership.", children: ['ownership', 'structs'] },
-  { id: 'ownership', name: 'Ownership', icon: '🔑', unlocked: true, katasCompleted: 0, katasTotal: 1, x: 180, y: 144, size: 87, color: '#3d9bff', description: "Chaque valeur a un unique propriétaire. Quand il sort du scope, la valeur est libérée. Le cœur de la sûreté mémoire de Rust.", children: ['lifetimes', 'structs'] },
-  { id: 'structs', name: 'Structs', icon: '📦', unlocked: true, katasCompleted: 0, katasTotal: 2, x: 660, y: 144, size: 87, color: '#3d9bff', description: "Regroupe des données liées. Méthodes via impl. Base des types personnalisés et des traits.", children: ['traits', 'generics'] },
-  { id: 'lifetimes', name: 'Lifetimes', icon: '⏳', unlocked: false, katasCompleted: 0, katasTotal: 1, x: 75, y: 282, size: 84, color: '#7f9cc4', description: "Annotations qui garantissent qu'une référence ne survit pas à la donnée qu'elle pointe.", children: ['traits'] },
-  { id: 'borrowing', name: 'Borrowing', icon: '🤝', unlocked: false, katasCompleted: 0, katasTotal: 1, x: 300, y: 282, size: 84, color: '#7f9cc4', description: "Emprunte une valeur via une référence (&) sans en prendre la possession.", children: ['concurrency'] },
-  { id: 'traits', name: 'Traits', icon: '🔒', unlocked: false, katasCompleted: 0, katasTotal: 1, x: 75, y: 420, size: 81, color: '#7f9cc4', description: "Les interfaces de Rust. Définit des comportements partagés.", children: ['macros'] },
-  { id: 'concurrency', name: 'Concurrence', icon: '🔒', unlocked: false, katasCompleted: 0, katasTotal: 1, x: 660, y: 420, size: 81, color: '#7f9cc4', description: "Threads, Arc, Mutex, channels.", children: ['macros'] },
-  { id: 'macros', name: 'Macros', icon: '🔒', unlocked: false, katasCompleted: 0, katasTotal: 1, x: 398, y: 534, size: 81, color: '#7f9cc4', description: "Méta-programmation : génère du code à la compilation.", children: [] },
-  { id: 'generics', name: 'Génériques', icon: '🔒', unlocked: false, katasCompleted: 0, katasTotal: 1, x: 495, y: 282, size: 75, color: '#7f9cc4', description: "Paramétrise les types et fonctions.", children: [] },
-  { id: 'unsafe', name: 'Unsafe', icon: '🔒', unlocked: false, katasCompleted: 0, katasTotal: 1, x: 555, y: 420, size: 72, color: '#7f9cc4', description: "Pointeurs bruts, FFI, opérations non vérifiées.", children: [] }
+  { id: 'bases', name: 'Basics', icon: '⚙️', unlocked: true, katasCompleted: 3, katasTotal: 3, x: 420, y: 12, size: 93, color: '#3d9bff', description: "Variables, types, functions and control flow. The foundations before diving into ownership.", children: ['ownership', 'structs'] },
+  { id: 'ownership', name: 'Ownership', icon: '🔑', unlocked: true, katasCompleted: 0, katasTotal: 1, x: 180, y: 144, size: 87, color: '#3d9bff', description: "Every value has a single owner. When it goes out of scope, the value is released. The heart of Rust's memory safety.", children: ['lifetimes', 'structs'] },
+  { id: 'structs', name: 'Structs', icon: '📦', unlocked: true, katasCompleted: 0, katasTotal: 2, x: 660, y: 144, size: 87, color: '#3d9bff', description: "Group related data together. Methods via impl. The basis for custom types and traits.", children: ['traits', 'generics'] },
+  { id: 'lifetimes', name: 'Lifetimes', icon: '⏳', unlocked: false, katasCompleted: 0, katasTotal: 1, x: 75, y: 282, size: 84, color: '#7f9cc4', description: "Annotations that guarantee a reference doesn't outlive the data it points to.", children: ['traits'] },
+  { id: 'borrowing', name: 'Borrowing', icon: '🤝', unlocked: false, katasCompleted: 0, katasTotal: 1, x: 300, y: 282, size: 84, color: '#7f9cc4', description: "Borrow a value via a reference (&) without taking ownership of it.", children: ['concurrency'] },
+  { id: 'traits', name: 'Traits', icon: '🔒', unlocked: false, katasCompleted: 0, katasTotal: 1, x: 75, y: 420, size: 81, color: '#7f9cc4', description: "Rust's interfaces. Defines shared behaviors.", children: ['macros'] },
+  { id: 'concurrency', name: 'Concurrency', icon: '🔒', unlocked: false, katasCompleted: 0, katasTotal: 1, x: 660, y: 420, size: 81, color: '#7f9cc4', description: "Threads, Arc, Mutex, channels.", children: ['macros'] },
+  { id: 'macros', name: 'Macros', icon: '🔒', unlocked: false, katasCompleted: 0, katasTotal: 1, x: 398, y: 534, size: 81, color: '#7f9cc4', description: "Meta-programming: generates code at compile time.", children: [] },
+  { id: 'generics', name: 'Generics', icon: '🔒', unlocked: false, katasCompleted: 0, katasTotal: 1, x: 495, y: 282, size: 75, color: '#7f9cc4', description: "Parametrize types and functions.", children: [] },
+  { id: 'unsafe', name: 'Unsafe', icon: '🔒', unlocked: false, katasCompleted: 0, katasTotal: 1, x: 555, y: 420, size: 72, color: '#7f9cc4', description: "Raw pointers, FFI, unchecked operations.", children: [] }
 ]
 
 export const GRAAL_CHAPTERS = [
-  { title: 'Ownership & Borrowing', sub: '11 katas · maîtrisé', done: true },
-  { title: 'Lifetimes', sub: '5 katas · en cours', done: false },
-  { title: 'Traits & Génériques', sub: '12 katas · verrouillé', done: false },
-  { title: 'Concurrence', sub: '6 katas · verrouillé', done: false },
-  { title: 'Macros & Unsafe', sub: '8 katas · verrouillé', done: false }
+  { title: 'Ownership & Borrowing', sub: '11 katas · mastered', done: true },
+  { title: 'Lifetimes', sub: '5 katas · in progress', done: false },
+  { title: 'Traits & Generics', sub: '12 katas · locked', done: false },
+  { title: 'Concurrency', sub: '6 katas · locked', done: false },
+  { title: 'Macros & Unsafe', sub: '8 katas · locked', done: false }
 ]

--- a/academy/src/data/katas.generated.ts
+++ b/academy/src/data/katas.generated.ts
@@ -101,8 +101,8 @@ We can just run the exercise by calling \`cargo run --bin <exercise_n>\` to run 
 
 - Join the Rust community on forums such as the Rust Users Forum ([https://users.rust-lang.org/](https://users.rust-lang.org/)) or the Rust subreddit ([https://www.reddit.com/r/rust/](https://www.reddit.com/r/rust/)) for support and discussions.`,
     tests: [
-      { name: 'no_todo_remaining', description: 'Aucun todo!() restant', check: (c) => !/todo!\s*\(\s*\)/.test(c) },
-      { name: 'solution_pattern', description: 'Code non vide', check: (c) => c.trim().length > 0 }
+      { name: 'no_todo_remaining', description: 'No todo!() left', check: (c) => !/todo!\s*\(\s*\)/.test(c) },
+      { name: 'solution_pattern', description: 'Code not empty', check: (c) => c.trim().length > 0 }
     ],
     starterCode: `fn main() {
     // See README.md
@@ -152,8 +152,8 @@ fn defeat_beast(health: i32, stamina: f32) -> String {
 }
 `,
     hints: [
-      `💡 Regarde le README.md dans \`katas/01-starter/00-rustward-sword/\` pour les consignes.`,
-      `💡 Consulte la solution dans \`katas/01-starter/00-rustward-sword/solutions/\` si tu bloques.`
+      `💡 Check the README.md in \`katas/01-starter/00-rustward-sword/\` for the instructions.`,
+      `💡 Check the solution in \`katas/01-starter/00-rustward-sword/solutions/\` if you're stuck.`
     ],
   },
   {
@@ -228,8 +228,8 @@ Access to the Rust documentation at https://doc.rust-lang.org/std/index.html
 
 Acces to the Rust book at https://doc.rust-lang.org/book/`,
     tests: [
-      { name: 'no_todo_remaining', description: 'Aucun todo!() restant', check: (c) => !/todo!\s*\(\s*\)/.test(c) },
-      { name: 'solution_pattern', description: 'Code non vide', check: (c) => c.trim().length > 0 }
+      { name: 'no_todo_remaining', description: 'No todo!() left', check: (c) => !/todo!\s*\(\s*\)/.test(c) },
+      { name: 'solution_pattern', description: 'Code not empty', check: (c) => c.trim().length > 0 }
     ],
     starterCode: `use std::fmt::{Display, Formatter, Result};
 
@@ -773,8 +773,8 @@ mod tests {
 }
 `,
     hints: [
-      `💡 Regarde le README.md dans \`katas/01-starter/01-roman-numerals/\` pour les consignes.`,
-      `💡 Consulte la solution dans \`katas/01-starter/01-roman-numerals/solutions/\` si tu bloques.`
+      `💡 Check the README.md in \`katas/01-starter/01-roman-numerals/\` for the instructions.`,
+      `💡 Check the solution in \`katas/01-starter/01-roman-numerals/solutions/\` if you're stuck.`
     ],
   },
   {
@@ -862,7 +862,7 @@ Access to the Rust documentation at https://doc.rust-lang.org/std/index.html
 
 Acces to the Rust book at https://doc.rust-lang.org/book/`,
     tests: [
-      { name: 'solution_pattern', description: 'Code non vide', check: (c) => c.trim().length > 0 }
+      { name: 'solution_pattern', description: 'Code not empty', check: (c) => c.trim().length > 0 }
     ],
     starterCode: `pub mod cli {
     pub fn print_header() {
@@ -1424,8 +1424,8 @@ impl RPNStack {
 }
 `,
     hints: [
-      `💡 Regarde le README.md dans \`katas/01-starter/02-rpn_calculator/\` pour les consignes.`,
-      `💡 Consulte la solution dans \`katas/01-starter/02-rpn_calculator/solutions/\` si tu bloques.`
+      `💡 Check the README.md in \`katas/01-starter/02-rpn_calculator/\` for the instructions.`,
+      `💡 Check the solution in \`katas/01-starter/02-rpn_calculator/solutions/\` if you're stuck.`
     ],
   },
   {
@@ -1490,7 +1490,7 @@ Access to the Rust documentation at https://doc.rust-lang.org/std/index.html
 
 Acces to the Rust book at https://doc.rust-lang.org/book/`,
     tests: [
-      { name: 'solution_pattern', description: 'Code non vide', check: (c) => c.trim().length > 0 }
+      { name: 'solution_pattern', description: 'Code not empty', check: (c) => c.trim().length > 0 }
     ],
     starterCode: `struct Container {
     str: String,
@@ -1718,8 +1718,8 @@ fn string_uppercase(data: &mut String) {
 }
 `,
     hints: [
-      `💡 Ce kata nécessite de comprendre les concepts avancés — relis le README.md.`,
-      `💡 Les fichiers solutions dans \`katas/01-starter/03-ownership-borrowing/solutions/\` contiennent la correction.`
+      `💡 This kata requires understanding advanced concepts — re-read the README.md.`,
+      `💡 The solution files in \`katas/01-starter/03-ownership-borrowing/solutions/\` contain the fix.`
     ],
   },
   {
@@ -1771,8 +1771,8 @@ The SETUP package must have been completed
 Access to the Rust documentation at https://doc.rust-lang.org/std/index.html
 Access to the Rust book at https://doc.rust-lang.org/book/`,
     tests: [
-      { name: 'no_todo_remaining', description: 'Aucun todo!() restant', check: (c) => !/todo!\s*\(\s*\)/.test(c) },
-      { name: 'solution_pattern', description: 'Code non vide', check: (c) => c.trim().length > 0 }
+      { name: 'no_todo_remaining', description: 'No todo!() left', check: (c) => !/todo!\s*\(\s*\)/.test(c) },
+      { name: 'solution_pattern', description: 'Code not empty', check: (c) => c.trim().length > 0 }
     ],
     starterCode: `// TODO 1: Implement the fizz_buzz function that takes a u32 and returns a String.
 // - For multiples of 3, return "Fizz"
@@ -1865,8 +1865,8 @@ mod tests {
 }
 `,
     hints: [
-      `💡 Regarde le README.md dans \`katas/01-starter/04-fizzbuzz/\` pour les consignes.`,
-      `💡 Consulte la solution dans \`katas/01-starter/04-fizzbuzz/solutions/\` si tu bloques.`
+      `💡 Check the README.md in \`katas/01-starter/04-fizzbuzz/\` for the instructions.`,
+      `💡 Check the solution in \`katas/01-starter/04-fizzbuzz/solutions/\` if you're stuck.`
     ],
   },
   {
@@ -1922,8 +1922,8 @@ The SETUP package must have been completed
 Access to the Rust documentation at https://doc.rust-lang.org/std/index.html
 Access to the Rust book at https://doc.rust-lang.org/book/`,
     tests: [
-      { name: 'no_todo_remaining', description: 'Aucun todo!() restant', check: (c) => !/todo!\s*\(\s*\)/.test(c) },
-      { name: 'solution_pattern', description: 'Code non vide', check: (c) => c.trim().length > 0 }
+      { name: 'no_todo_remaining', description: 'No todo!() left', check: (c) => !/todo!\s*\(\s*\)/.test(c) },
+      { name: 'solution_pattern', description: 'Code not empty', check: (c) => c.trim().length > 0 }
     ],
     starterCode: `// TODO 1: Implement the is_leap_year function that takes a u32 year and returns a bool.
 // Rules:
@@ -2038,8 +2038,8 @@ mod tests {
 }
 `,
     hints: [
-      `💡 Regarde le README.md dans \`katas/01-starter/05-leap-years/\` pour les consignes.`,
-      `💡 Consulte la solution dans \`katas/01-starter/05-leap-years/solutions/\` si tu bloques.`
+      `💡 Check the README.md in \`katas/01-starter/05-leap-years/\` for the instructions.`,
+      `💡 Check the solution in \`katas/01-starter/05-leap-years/solutions/\` if you're stuck.`
     ],
   },
   {
@@ -2099,8 +2099,8 @@ The SETUP package must have been completed
 Access to the Rust documentation at https://doc.rust-lang.org/std/index.html
 Access to the Rust book at https://doc.rust-lang.org/book/`,
     tests: [
-      { name: 'no_todo_remaining', description: 'Aucun todo!() restant', check: (c) => !/todo!\s*\(\s*\)/.test(c) },
-      { name: 'solution_pattern', description: 'Code non vide', check: (c) => c.trim().length > 0 }
+      { name: 'no_todo_remaining', description: 'No todo!() left', check: (c) => !/todo!\s*\(\s*\)/.test(c) },
+      { name: 'solution_pattern', description: 'Code not empty', check: (c) => c.trim().length > 0 }
     ],
     starterCode: `// A game of bowling consists of 10 frames.
 // Each roll knocks down 0-10 pins.
@@ -2238,8 +2238,8 @@ mod tests {
 }
 `,
     hints: [
-      `💡 Regarde le README.md dans \`katas/01-starter/06-bowling/\` pour les consignes.`,
-      `💡 Consulte la solution dans \`katas/01-starter/06-bowling/solutions/\` si tu bloques.`
+      `💡 Check the README.md in \`katas/01-starter/06-bowling/\` for the instructions.`,
+      `💡 Check the solution in \`katas/01-starter/06-bowling/solutions/\` if you're stuck.`
     ],
   },
   {
@@ -2298,8 +2298,8 @@ The SETUP package must have been completed
 Access to the Rust documentation at https://doc.rust-lang.org/std/index.html
 Access to the Rust book at https://doc.rust-lang.org/book/`,
     tests: [
-      { name: 'no_todo_remaining', description: 'Aucun todo!() restant', check: (c) => !/todo!\s*\(\s*\)/.test(c) },
-      { name: 'solution_pattern', description: 'Code non vide', check: (c) => c.trim().length > 0 }
+      { name: 'no_todo_remaining', description: 'No todo!() left', check: (c) => !/todo!\s*\(\s*\)/.test(c) },
+      { name: 'solution_pattern', description: 'Code not empty', check: (c) => c.trim().length > 0 }
     ],
     starterCode: `// TODO 1: Implement the add function that takes a string of comma-separated numbers and returns their sum as a Result.
 // Steps to implement:
@@ -2491,8 +2491,8 @@ mod tests {
 }
 `,
     hints: [
-      `💡 Ce kata nécessite de comprendre les concepts avancés — relis le README.md.`,
-      `💡 Les fichiers solutions dans \`katas/01-starter/07-string-calculator/solutions/\` contiennent la correction.`
+      `💡 This kata requires understanding advanced concepts — re-read the README.md.`,
+      `💡 The solution files in \`katas/01-starter/07-string-calculator/solutions/\` contain the fix.`
     ],
   },
   {
@@ -2550,8 +2550,8 @@ The SETUP package must have been completed
 Access to the Rust documentation at https://doc.rust-lang.org/std/index.html
 Access to the Rust book at https://doc.rust-lang.org/book/`,
     tests: [
-      { name: 'no_todo_remaining', description: 'Aucun todo!() restant', check: (c) => !/todo!\s*\(\s*\)/.test(c) },
-      { name: 'solution_pattern', description: 'Code non vide', check: (c) => c.trim().length > 0 }
+      { name: 'no_todo_remaining', description: 'No todo!() left', check: (c) => !/todo!\s*\(\s*\)/.test(c) },
+      { name: 'solution_pattern', description: 'Code not empty', check: (c) => c.trim().length > 0 }
     ],
     starterCode: `// TODO 1: Implement the Tennis struct and its methods.
 // - new() creates a game with both players at 0
@@ -2766,8 +2766,8 @@ mod tests {
 }
 `,
     hints: [
-      `💡 Ce kata nécessite de comprendre les concepts avancés — relis le README.md.`,
-      `💡 Les fichiers solutions dans \`katas/01-starter/08-tennis/solutions/\` contiennent la correction.`
+      `💡 This kata requires understanding advanced concepts — re-read the README.md.`,
+      `💡 The solution files in \`katas/01-starter/08-tennis/solutions/\` contain the fix.`
     ],
   },
   {
@@ -2839,8 +2839,8 @@ The SETUP package must have been completed
 Access to the Rust documentation at https://doc.rust-lang.org/std/index.html
 Access to the Rust book at https://doc.rust-lang.org/book/`,
     tests: [
-      { name: 'no_todo_remaining', description: 'Aucun todo!() restant', check: (c) => !/todo!\s*\(\s*\)/.test(c) },
-      { name: 'solution_pattern', description: 'Code non vide', check: (c) => c.trim().length > 0 }
+      { name: 'no_todo_remaining', description: 'No todo!() left', check: (c) => !/todo!\s*\(\s*\)/.test(c) },
+      { name: 'solution_pattern', description: 'Code not empty', check: (c) => c.trim().length > 0 }
     ],
     starterCode: `// TODO 1: Implement compute(n: u32) -> String
 // Rules:
@@ -2978,8 +2978,8 @@ mod tests {
 }
 `,
     hints: [
-      `💡 Regarde le README.md dans \`katas/01-starter/09-foobaqix/\` pour les consignes.`,
-      `💡 Consulte la solution dans \`katas/01-starter/09-foobaqix/solutions/\` si tu bloques.`
+      `💡 Check the README.md in \`katas/01-starter/09-foobaqix/\` for the instructions.`,
+      `💡 Check the solution in \`katas/01-starter/09-foobaqix/solutions/\` if you're stuck.`
     ],
   },
   {
@@ -3004,7 +3004,7 @@ This kata as a part of the STARTER package targets Rust beginners.
 ## Context
 This kata is based on [Nim from Coding Dojo](https://codingdojo.org/kata/Nim/).
 
-Jeu de Nim à deux joueurs. Start with a pile of sticks. Each turn, a player removes 1, 2, or 3 sticks. The player who takes the **last** stick **loses**.
+Two-player Nim game. Start with a pile of sticks. Each turn, a player removes 1, 2, or 3 sticks. The player who takes the **last** stick **loses**.
 
 Given an initial number of sticks, determine which player wins with optimal play.
 
@@ -3046,8 +3046,8 @@ The SETUP package must have been completed
 Access to the Rust documentation at https://doc.rust-lang.org/std/index.html
 Access to the Rust book at https://doc.rust-lang.org/book/`,
     tests: [
-      { name: 'no_todo_remaining', description: 'Aucun todo!() restant', check: (c) => !/todo!\s*\(\s*\)/.test(c) },
-      { name: 'solution_pattern', description: 'Code non vide', check: (c) => c.trim().length > 0 }
+      { name: 'no_todo_remaining', description: 'No todo!() left', check: (c) => !/todo!\s*\(\s*\)/.test(c) },
+      { name: 'solution_pattern', description: 'Code not empty', check: (c) => c.trim().length > 0 }
     ],
     starterCode: `// TODO 1: Implement nim_winner(sticks: u32) -> &'static str
 // Rules:
@@ -3145,8 +3145,8 @@ mod tests {
 }
 `,
     hints: [
-      `💡 Regarde le README.md dans \`katas/01-starter/10-nim-game/\` pour les consignes.`,
-      `💡 Consulte la solution dans \`katas/01-starter/10-nim-game/solutions/\` si tu bloques.`
+      `💡 Check the README.md in \`katas/01-starter/10-nim-game/\` for the instructions.`,
+      `💡 Check the solution in \`katas/01-starter/10-nim-game/solutions/\` if you're stuck.`
     ],
   },
   {
@@ -3214,8 +3214,8 @@ The SETUP package must have been completed
 Access to the Rust documentation at https://doc.rust-lang.org/std/index.html
 Access to the Rust book at https://doc.rust-lang.org/book/`,
     tests: [
-      { name: 'no_todo_remaining', description: 'Aucun todo!() restant', check: (c) => !/todo!\s*\(\s*\)/.test(c) },
-      { name: 'solution_pattern', description: 'Code non vide', check: (c) => c.trim().length > 0 }
+      { name: 'no_todo_remaining', description: 'No todo!() left', check: (c) => !/todo!\s*\(\s*\)/.test(c) },
+      { name: 'solution_pattern', description: 'Code not empty', check: (c) => c.trim().length > 0 }
     ],
     starterCode: `// TODO: Implement wrap(text: &str, column: usize) -> String
 // Rules:
@@ -3335,8 +3335,8 @@ mod tests {
 }
 `,
     hints: [
-      `💡 Regarde le README.md dans \`katas/01-starter/11-word-wrap/\` pour les consignes.`,
-      `💡 Consulte la solution dans \`katas/01-starter/11-word-wrap/solutions/\` si tu bloques.`
+      `💡 Check the README.md in \`katas/01-starter/11-word-wrap/\` for the instructions.`,
+      `💡 Check the solution in \`katas/01-starter/11-word-wrap/solutions/\` if you're stuck.`
     ],
   },
   {
@@ -3420,8 +3420,8 @@ The SETUP package must have been completed
 Access to the Rust documentation at https://doc.rust-lang.org/std/index.html
 Access to the Rust book at https://doc.rust-lang.org/book/`,
     tests: [
-      { name: 'no_todo_remaining', description: 'Aucun todo!() restant', check: (c) => !/todo!\s*\(\s*\)/.test(c) },
-      { name: 'solution_pattern', description: 'Code non vide', check: (c) => c.trim().length > 0 }
+      { name: 'no_todo_remaining', description: 'No todo!() left', check: (c) => !/todo!\s*\(\s*\)/.test(c) },
+      { name: 'solution_pattern', description: 'Code not empty', check: (c) => c.trim().length > 0 }
     ],
     starterCode: `// TODO: Implement to_lcd(number: &str) -> String
 // Each digit is 3 characters wide, represented on 3 lines.
@@ -3532,8 +3532,8 @@ mod tests {
 }
 `,
     hints: [
-      `💡 Regarde le README.md dans \`katas/01-starter/12-number-to-lcd/\` pour les consignes.`,
-      `💡 Consulte la solution dans \`katas/01-starter/12-number-to-lcd/solutions/\` si tu bloques.`
+      `💡 Check the README.md in \`katas/01-starter/12-number-to-lcd/\` for the instructions.`,
+      `💡 Check the solution in \`katas/01-starter/12-number-to-lcd/solutions/\` if you're stuck.`
     ],
   },
   {
@@ -3612,8 +3612,8 @@ The SETUP package must have been completed
 Access to the Rust documentation at https://doc.rust-lang.org/std/index.html
 Access to the Rust book at https://doc.rust-lang.org/book/`,
     tests: [
-      { name: 'no_todo_remaining', description: 'Aucun todo!() restant', check: (c) => !/todo!\s*\(\s*\)/.test(c) },
-      { name: 'solution_pattern', description: 'Code non vide', check: (c) => c.trim().length > 0 }
+      { name: 'no_todo_remaining', description: 'No todo!() left', check: (c) => !/todo!\s*\(\s*\)/.test(c) },
+      { name: 'solution_pattern', description: 'Code not empty', check: (c) => c.trim().length > 0 }
     ],
     starterCode: `// TODO: Implement score(dice: &[u32]) -> u32
 // Scoring rules:
@@ -3756,8 +3756,8 @@ mod tests {
 }
 `,
     hints: [
-      `💡 Regarde le README.md dans \`katas/01-starter/13-greed/\` pour les consignes.`,
-      `💡 Consulte la solution dans \`katas/01-starter/13-greed/solutions/\` si tu bloques.`
+      `💡 Check the README.md in \`katas/01-starter/13-greed/\` for the instructions.`,
+      `💡 Check the solution in \`katas/01-starter/13-greed/solutions/\` if you're stuck.`
     ],
   },
   {
@@ -3880,8 +3880,8 @@ Access to the Rust documentation at https://doc.rust-lang.org/std/index.html
 
 Access to the Rust book at https://doc.rust-lang.org/book/`,
     tests: [
-      { name: 'no_todo_remaining', description: 'Aucun todo!() restant', check: (c) => !/todo!\s*\(\s*\)/.test(c) },
-      { name: 'solution_pattern', description: 'Code non vide', check: (c) => c.trim().length > 0 }
+      { name: 'no_todo_remaining', description: 'No todo!() left', check: (c) => !/todo!\s*\(\s*\)/.test(c) },
+      { name: 'solution_pattern', description: 'Code not empty', check: (c) => c.trim().length > 0 }
     ],
     starterCode: `/*
  * Section 5 : Combined Exercise
@@ -4348,7 +4348,7 @@ impl Sortable for CustomStruct {
 }
 `,
     hints: [
-      `💡 Regarde le README.md dans \`katas/02-structure/00-basics/\` pour les consignes.`
+      `💡 Check the README.md in \`katas/02-structure/00-basics/\` for the instructions.`
     ],
   },
   {
@@ -4518,8 +4518,8 @@ Access to the Rust documentation at https://doc.rust-lang.org/std/index.html
 
 Access to the Rust book at https://doc.rust-lang.org/book/`,
     tests: [
-      { name: 'no_todo_remaining', description: 'Aucun todo!() restant', check: (c) => !/todo!\s*\(\s*\)/.test(c) },
-      { name: 'solution_pattern', description: 'Code non vide', check: (c) => c.trim().length > 0 }
+      { name: 'no_todo_remaining', description: 'No todo!() left', check: (c) => !/todo!\s*\(\s*\)/.test(c) },
+      { name: 'solution_pattern', description: 'Code not empty', check: (c) => c.trim().length > 0 }
     ],
     starterCode: `/*
  * Section 1 : Box Smart Pointers
@@ -5206,8 +5206,8 @@ impl TreeNode2 {
 }
 `,
     hints: [
-      `💡 Ce kata nécessite de comprendre les concepts avancés — relis le README.md.`,
-      `💡 Les fichiers solutions dans \`katas/02-structure/01-smart-pointers/solutions/\` contiennent la correction.`
+      `💡 This kata requires understanding advanced concepts — re-read the README.md.`,
+      `💡 The solution files in \`katas/02-structure/01-smart-pointers/solutions/\` contain the fix.`
     ],
   },
   {
@@ -5273,8 +5273,8 @@ The SETUP and STARTER packages must have been completed
 Access to the Rust documentation at https://doc.rust-lang.org/std/index.html
 Access to the Rust book at https://doc.rust-lang.org/book/`,
     tests: [
-      { name: 'no_todo_remaining', description: 'Aucun todo!() restant', check: (c) => !/todo!\s*\(\s*\)/.test(c) },
-      { name: 'solution_pattern', description: 'Code non vide', check: (c) => c.trim().length > 0 }
+      { name: 'no_todo_remaining', description: 'No todo!() left', check: (c) => !/todo!\s*\(\s*\)/.test(c) },
+      { name: 'solution_pattern', description: 'Code not empty', check: (c) => c.trim().length > 0 }
     ],
     starterCode: `// TODO: Implement the Grid structure for Conway's Game of Life.
 // The grid is a 2D vector of booleans (true = alive, false = dead).
@@ -5495,8 +5495,8 @@ mod tests {
 }
 `,
     hints: [
-      `💡 Ce kata nécessite de comprendre les concepts avancés — relis le README.md.`,
-      `💡 Les fichiers solutions dans \`katas/02-structure/02-game-of-life/solutions/\` contiennent la correction.`
+      `💡 This kata requires understanding advanced concepts — re-read the README.md.`,
+      `💡 The solution files in \`katas/02-structure/02-game-of-life/solutions/\` contain the fix.`
     ],
   },
   {
@@ -5546,8 +5546,8 @@ The SETUP and STARTER packages must have been completed
 Access to the Rust documentation at https://doc.rust-lang.org/std/index.html
 Access to the Rust book at https://doc.rust-lang.org/book/`,
     tests: [
-      { name: 'no_todo_remaining', description: 'Aucun todo!() restant', check: (c) => !/todo!\s*\(\s*\)/.test(c) },
-      { name: 'solution_pattern', description: 'Code non vide', check: (c) => c.trim().length > 0 }
+      { name: 'no_todo_remaining', description: 'No todo!() left', check: (c) => !/todo!\s*\(\s*\)/.test(c) },
+      { name: 'solution_pattern', description: 'Code not empty', check: (c) => c.trim().length > 0 }
     ],
     starterCode: `// TODO: Implement the annotate function that takes a minefield (Vec<&str> or Vec<String>)
 // and returns the annotated field where each safe square '.' is replaced by a digit
@@ -5731,8 +5731,8 @@ mod tests {
 }
 `,
     hints: [
-      `💡 Ce kata nécessite de comprendre les concepts avancés — relis le README.md.`,
-      `💡 Les fichiers solutions dans \`katas/02-structure/03-minesweeper/solutions/\` contiennent la correction.`
+      `💡 This kata requires understanding advanced concepts — re-read the README.md.`,
+      `💡 The solution files in \`katas/02-structure/03-minesweeper/solutions/\` contain the fix.`
     ],
   },
   {
@@ -5797,8 +5797,8 @@ The SETUP and STARTER packages must have been completed
 Access to the Rust documentation at https://doc.rust-lang.org/std/index.html
 Access to the Rust book at https://doc.rust-lang.org/book/`,
     tests: [
-      { name: 'no_todo_remaining', description: 'Aucun todo!() restant', check: (c) => !/todo!\s*\(\s*\)/.test(c) },
-      { name: 'solution_pattern', description: 'Code non vide', check: (c) => c.trim().length > 0 }
+      { name: 'no_todo_remaining', description: 'No todo!() left', check: (c) => !/todo!\s*\(\s*\)/.test(c) },
+      { name: 'solution_pattern', description: 'Code not empty', check: (c) => c.trim().length > 0 }
     ],
     starterCode: `// TODO: Implement Card and Suit types
 
@@ -6179,8 +6179,8 @@ mod tests {
 }
 `,
     hints: [
-      `💡 Ce kata nécessite de comprendre les concepts avancés — relis le README.md.`,
-      `💡 Les fichiers solutions dans \`katas/02-structure/04-poker-hands/solutions/\` contiennent la correction.`
+      `💡 This kata requires understanding advanced concepts — re-read the README.md.`,
+      `💡 The solution files in \`katas/02-structure/04-poker-hands/solutions/\` contain the fix.`
     ],
   },
   {
@@ -6239,8 +6239,8 @@ The SETUP and STARTER packages must have been completed
 Access to the Rust documentation at https://doc.rust-lang.org/std/index.html
 Access to the Rust book at https://doc.rust-lang.org/book/`,
     tests: [
-      { name: 'no_todo_remaining', description: 'Aucun todo!() restant', check: (c) => !/todo!\s*\(\s*\)/.test(c) },
-      { name: 'solution_pattern', description: 'Code non vide', check: (c) => c.trim().length > 0 }
+      { name: 'no_todo_remaining', description: 'No todo!() left', check: (c) => !/todo!\s*\(\s*\)/.test(c) },
+      { name: 'solution_pattern', description: 'Code not empty', check: (c) => c.trim().length > 0 }
     ],
     starterCode: `// TODO: Implement the diamond function that takes a char (A-Z) and returns
 // a vector of strings representing the diamond shape.
@@ -6360,8 +6360,8 @@ mod tests {
 }
 `,
     hints: [
-      `💡 Ce kata nécessite de comprendre les concepts avancés — relis le README.md.`,
-      `💡 Les fichiers solutions dans \`katas/02-structure/05-diamond/solutions/\` contiennent la correction.`
+      `💡 This kata requires understanding advanced concepts — re-read the README.md.`,
+      `💡 The solution files in \`katas/02-structure/05-diamond/solutions/\` contain the fix.`
     ],
   },
   {
@@ -6411,8 +6411,8 @@ The SETUP and STARTER packages must have been completed
 Access to the Rust documentation at https://doc.rust-lang.org/std/index.html
 Access to the Rust book at https://doc.rust-lang.org/book/`,
     tests: [
-      { name: 'no_todo_remaining', description: 'Aucun todo!() restant', check: (c) => !/todo!\s*\(\s*\)/.test(c) },
-      { name: 'solution_pattern', description: 'Code non vide', check: (c) => c.trim().length > 0 }
+      { name: 'no_todo_remaining', description: 'No todo!() left', check: (c) => !/todo!\s*\(\s*\)/.test(c) },
+      { name: 'solution_pattern', description: 'Code not empty', check: (c) => c.trim().length > 0 }
     ],
     starterCode: `// TODO: Implement the Yahtzee scoring system
 // Categories: Ones, Twos, ..., Sixes = sum of matching dice
@@ -6649,8 +6649,8 @@ mod tests {
 }
 `,
     hints: [
-      `💡 Ce kata nécessite de comprendre les concepts avancés — relis le README.md.`,
-      `💡 Les fichiers solutions dans \`katas/02-structure/06-yahtzee/solutions/\` contiennent la correction.`
+      `💡 This kata requires understanding advanced concepts — re-read the README.md.`,
+      `💡 The solution files in \`katas/02-structure/06-yahtzee/solutions/\` contain the fix.`
     ],
   },
   {
@@ -6705,8 +6705,8 @@ The SETUP and STARTER packages must have been completed
 Access to the Rust documentation at https://doc.rust-lang.org/std/index.html
 Access to the Rust book at https://doc.rust-lang.org/book/`,
     tests: [
-      { name: 'no_todo_remaining', description: 'Aucun todo!() restant', check: (c) => !/todo!\s*\(\s*\)/.test(c) },
-      { name: 'solution_pattern', description: 'Code non vide', check: (c) => c.trim().length > 0 }
+      { name: 'no_todo_remaining', description: 'No todo!() left', check: (c) => !/todo!\s*\(\s*\)/.test(c) },
+      { name: 'solution_pattern', description: 'Code not empty', check: (c) => c.trim().length > 0 }
     ],
     starterCode: `// TODO: Implement berlin_clock(time: &str) -> String
 // Input: "HH:MM:SS"
@@ -6812,8 +6812,8 @@ mod tests {
 }
 `,
     hints: [
-      `💡 Ce kata nécessite de comprendre les concepts avancés — relis le README.md.`,
-      `💡 Les fichiers solutions dans \`katas/02-structure/07-berlin-clock/solutions/\` contiennent la correction.`
+      `💡 This kata requires understanding advanced concepts — re-read the README.md.`,
+      `💡 The solution files in \`katas/02-structure/07-berlin-clock/solutions/\` contain the fix.`
     ],
   },
   {
@@ -6870,7 +6870,7 @@ The SETUP and STARTER packages must have been completed
 Access to the Rust documentation at https://doc.rust-lang.org/std/index.html
 Access to the Rust book at https://doc.rust-lang.org/book/`,
     tests: [
-      { name: 'solution_pattern', description: 'Code non vide', check: (c) => c.trim().length > 0 }
+      { name: 'solution_pattern', description: 'Code not empty', check: (c) => c.trim().length > 0 }
     ],
     starterCode: `// This is the legacy code of the Gilded Rose inn.
 // TODO 1: Write tests to characterize existing behavior (Characterization Tests)
@@ -7124,8 +7124,8 @@ mod tests {
 }
 `,
     hints: [
-      `💡 Ce kata nécessite de comprendre les concepts avancés — relis le README.md.`,
-      `💡 Les fichiers solutions dans \`katas/02-structure/08-gilded-rose/solutions/\` contiennent la correction.`
+      `💡 This kata requires understanding advanced concepts — re-read the README.md.`,
+      `💡 The solution files in \`katas/02-structure/08-gilded-rose/solutions/\` contain the fix.`
     ],
   },
   {
@@ -7180,8 +7180,8 @@ The SETUP and STARTER packages must have been completed
 Access to the Rust documentation at https://doc.rust-lang.org/std/index.html
 Access to the Rust book at https://doc.rust-lang.org/book/`,
     tests: [
-      { name: 'no_todo_remaining', description: 'Aucun todo!() restant', check: (c) => !/todo!\s*\(\s*\)/.test(c) },
-      { name: 'solution_pattern', description: 'Code non vide', check: (c) => c.trim().length > 0 }
+      { name: 'no_todo_remaining', description: 'No todo!() left', check: (c) => !/todo!\s*\(\s*\)/.test(c) },
+      { name: 'solution_pattern', description: 'Code not empty', check: (c) => c.trim().length > 0 }
     ],
     starterCode: `// TODO: Implement integer range with open/closed bounds
 // Notation: [a,b) = closed start, open end
@@ -7388,8 +7388,8 @@ mod tests {
 }
 `,
     hints: [
-      `💡 Ce kata nécessite de comprendre les concepts avancés — relis le README.md.`,
-      `💡 Les fichiers solutions dans \`katas/02-structure/09-range/solutions/\` contiennent la correction.`
+      `💡 This kata requires understanding advanced concepts — re-read the README.md.`,
+      `💡 The solution files in \`katas/02-structure/09-range/solutions/\` contain the fix.`
     ],
   },
   {
@@ -7439,8 +7439,8 @@ The SETUP and STARTER packages must have been completed
 Access to the Rust documentation at https://doc.rust-lang.org/std/index.html
 Access to the Rust book at https://doc.rust-lang.org/book/`,
     tests: [
-      { name: 'no_todo_remaining', description: 'Aucun todo!() restant', check: (c) => !/todo!\s*\(\s*\)/.test(c) },
-      { name: 'solution_pattern', description: 'Code non vide', check: (c) => c.trim().length > 0 }
+      { name: 'no_todo_remaining', description: 'No todo!() left', check: (c) => !/todo!\s*\(\s*\)/.test(c) },
+      { name: 'solution_pattern', description: 'Code not empty', check: (c) => c.trim().length > 0 }
     ],
     starterCode: `// TODO: Implement Birthday Greetings with Hexagonal Architecture
 //
@@ -7662,8 +7662,8 @@ mod tests {
 }
 `,
     hints: [
-      `💡 Ce kata nécessite de comprendre les concepts avancés — relis le README.md.`,
-      `💡 Les fichiers solutions dans \`katas/02-structure/10-birthday-greetings/solutions/\` contiennent la correction.`
+      `💡 This kata requires understanding advanced concepts — re-read the README.md.`,
+      `💡 The solution files in \`katas/02-structure/10-birthday-greetings/solutions/\` contain the fix.`
     ],
   },
   {
@@ -7713,8 +7713,8 @@ The SETUP and STARTER packages must have been completed
 Access to the Rust documentation at https://doc.rust-lang.org/std/index.html
 Access to the Rust book at https://doc.rust-lang.org/book/`,
     tests: [
-      { name: 'no_todo_remaining', description: 'Aucun todo!() restant', check: (c) => !/todo!\s*\(\s*\)/.test(c) },
-      { name: 'solution_pattern', description: 'Code non vide', check: (c) => c.trim().length > 0 }
+      { name: 'no_todo_remaining', description: 'No todo!() left', check: (c) => !/todo!\s*\(\s*\)/.test(c) },
+      { name: 'solution_pattern', description: 'Code not empty', check: (c) => c.trim().length > 0 }
     ],
     starterCode: `// TODO: Implement Wallet valuation system
 //
@@ -7930,8 +7930,8 @@ mod tests {
 }
 `,
     hints: [
-      `💡 Ce kata nécessite de comprendre les concepts avancés — relis le README.md.`,
-      `💡 Les fichiers solutions dans \`katas/02-structure/11-wallet/solutions/\` contiennent la correction.`
+      `💡 This kata requires understanding advanced concepts — re-read the README.md.`,
+      `💡 The solution files in \`katas/02-structure/11-wallet/solutions/\` contain the fix.`
     ],
   },
   {
@@ -7981,8 +7981,8 @@ The SETUP and STARTER packages must have been completed
 Access to the Rust documentation at https://doc.rust-lang.org/std/index.html
 Access to the Rust book at https://doc.rust-lang.org/book/`,
     tests: [
-      { name: 'no_todo_remaining', description: 'Aucun todo!() restant', check: (c) => !/todo!\s*\(\s*\)/.test(c) },
-      { name: 'solution_pattern', description: 'Code non vide', check: (c) => c.trim().length > 0 }
+      { name: 'no_todo_remaining', description: 'No todo!() left', check: (c) => !/todo!\s*\(\s*\)/.test(c) },
+      { name: 'solution_pattern', description: 'Code not empty', check: (c) => c.trim().length > 0 }
     ],
     starterCode: `// TODO: Implement a two-player Trading Card Game
 //
@@ -8283,8 +8283,8 @@ mod tests {
 }
 `,
     hints: [
-      `💡 Ce kata nécessite de comprendre les concepts avancés — relis le README.md.`,
-      `💡 Les fichiers solutions dans \`katas/02-structure/12-trading-card-game/solutions/\` contiennent la correction.`
+      `💡 This kata requires understanding advanced concepts — re-read the README.md.`,
+      `💡 The solution files in \`katas/02-structure/12-trading-card-game/solutions/\` contain the fix.`
     ],
   },
   {
@@ -8334,8 +8334,8 @@ The SETUP and STARTER packages must have been completed
 Access to the Rust documentation at https://doc.rust-lang.org/std/index.html
 Access to the Rust book at https://doc.rust-lang.org/book/`,
     tests: [
-      { name: 'no_todo_remaining', description: 'Aucun todo!() restant', check: (c) => !/todo!\s*\(\s*\)/.test(c) },
-      { name: 'solution_pattern', description: 'Code non vide', check: (c) => c.trim().length > 0 }
+      { name: 'no_todo_remaining', description: 'No todo!() left', check: (c) => !/todo!\s*\(\s*\)/.test(c) },
+      { name: 'solution_pattern', description: 'Code not empty', check: (c) => c.trim().length > 0 }
     ],
     starterCode: `// TODO: Implement a simple social network
 //
@@ -8566,8 +8566,8 @@ mod tests {
 }
 `,
     hints: [
-      `💡 Ce kata nécessite de comprendre les concepts avancés — relis le README.md.`,
-      `💡 Les fichiers solutions dans \`katas/02-structure/13-social-network/solutions/\` contiennent la correction.`
+      `💡 This kata requires understanding advanced concepts — re-read the README.md.`,
+      `💡 The solution files in \`katas/02-structure/13-social-network/solutions/\` contain the fix.`
     ],
   },
   {
@@ -8617,8 +8617,8 @@ The SETUP and STARTER packages must have been completed
 Access to the Rust documentation at https://doc.rust-lang.org/std/index.html
 Access to the Rust book at https://doc.rust-lang.org/book/`,
     tests: [
-      { name: 'no_todo_remaining', description: 'Aucun todo!() restant', check: (c) => !/todo!\s*\(\s*\)/.test(c) },
-      { name: 'solution_pattern', description: 'Code non vide', check: (c) => c.trim().length > 0 }
+      { name: 'no_todo_remaining', description: 'No todo!() left', check: (c) => !/todo!\s*\(\s*\)/.test(c) },
+      { name: 'solution_pattern', description: 'Code not empty', check: (c) => c.trim().length > 0 }
     ],
     starterCode: `// TODO: Implement anagrams_of(word: &str, candidates: &[&str]) -> Vec<String>
 //
@@ -8746,8 +8746,8 @@ mod tests {
 }
 `,
     hints: [
-      `💡 Ce kata nécessite de comprendre les concepts avancés — relis le README.md.`,
-      `💡 Les fichiers solutions dans \`katas/02-structure/14-anagram/solutions/\` contiennent la correction.`
+      `💡 This kata requires understanding advanced concepts — re-read the README.md.`,
+      `💡 The solution files in \`katas/02-structure/14-anagram/solutions/\` contain the fix.`
     ],
   },
   {
@@ -8797,8 +8797,8 @@ The SETUP and STARTER packages must have been completed
 Access to the Rust documentation at https://doc.rust-lang.org/std/index.html
 Access to the Rust book at https://doc.rust-lang.org/book/`,
     tests: [
-      { name: 'no_todo_remaining', description: 'Aucun todo!() restant', check: (c) => !/todo!\s*\(\s*\)/.test(c) },
-      { name: 'solution_pattern', description: 'Code non vide', check: (c) => c.trim().length > 0 }
+      { name: 'no_todo_remaining', description: 'No todo!() left', check: (c) => !/todo!\s*\(\s*\)/.test(c) },
+      { name: 'solution_pattern', description: 'Code not empty', check: (c) => c.trim().length > 0 }
     ],
     starterCode: `// TODO: Parse OCR account numbers
 //
@@ -8973,8 +8973,8 @@ mod tests {
 }
 `,
     hints: [
-      `💡 Ce kata nécessite de comprendre les concepts avancés — relis le README.md.`,
-      `💡 Les fichiers solutions dans \`katas/02-structure/15-bank-ocr/solutions/\` contiennent la correction.`
+      `💡 This kata requires understanding advanced concepts — re-read the README.md.`,
+      `💡 The solution files in \`katas/02-structure/15-bank-ocr/solutions/\` contain the fix.`
     ],
   },
   {
@@ -9043,8 +9043,8 @@ The SETUP, STARTER and STRUCTURE packages must have been completed
 Access to the Rust documentation at https://doc.rust-lang.org/std/index.html
 Access to the Rust book at https://doc.rust-lang.org/book/`,
     tests: [
-      { name: 'no_todo_remaining', description: 'Aucun todo!() restant', check: (c) => !/todo!\s*\(\s*\)/.test(c) },
-      { name: 'solution_pattern', description: 'Code non vide', check: (c) => c.trim().length > 0 }
+      { name: 'no_todo_remaining', description: 'No todo!() left', check: (c) => !/todo!\s*\(\s*\)/.test(c) },
+      { name: 'solution_pattern', description: 'Code not empty', check: (c) => c.trim().length > 0 }
     ],
     starterCode: `mod map;
 mod rover;
@@ -9346,7 +9346,7 @@ impl Rover {
 }
 `,
     hints: [
-      `💡 Regarde le README.md dans \`katas/03-advanced/00-mars-rover/\` pour les consignes.`
+      `💡 Check the README.md in \`katas/03-advanced/00-mars-rover/\` for the instructions.`
     ],
   },
   {
@@ -9396,8 +9396,8 @@ The SETUP, STARTER and STRUCTURE packages must have been completed
 Access to the Rust documentation at https://doc.rust-lang.org/std/index.html
 Access to the Rust book at https://doc.rust-lang.org/book/`,
     tests: [
-      { name: 'no_todo_remaining', description: 'Aucun todo!() restant', check: (c) => !/todo!\s*\(\s*\)/.test(c) },
-      { name: 'solution_pattern', description: 'Code non vide', check: (c) => c.trim().length > 0 }
+      { name: 'no_todo_remaining', description: 'No todo!() left', check: (c) => !/todo!\s*\(\s*\)/.test(c) },
+      { name: 'solution_pattern', description: 'Code not empty', check: (c) => c.trim().length > 0 }
     ],
     starterCode: `// TODO: Implement a Sudoku solver using constraint propagation
 //
@@ -9736,7 +9736,7 @@ mod tests {
 }
 `,
     hints: [
-      `💡 Regarde le README.md dans \`katas/03-advanced/01-sudoku/\` pour les consignes.`
+      `💡 Check the README.md in \`katas/03-advanced/01-sudoku/\` for the instructions.`
     ],
   },
   {
@@ -9790,8 +9790,8 @@ The SETUP, STARTER and STRUCTURE packages must have been completed
 Access to the Rust documentation at https://doc.rust-lang.org/std/index.html
 Access to the Rust book at https://doc.rust-lang.org/book/`,
     tests: [
-      { name: 'no_todo_remaining', description: 'Aucun todo!() restant', check: (c) => !/todo!\s*\(\s*\)/.test(c) },
-      { name: 'solution_pattern', description: 'Code non vide', check: (c) => c.trim().length > 0 }
+      { name: 'no_todo_remaining', description: 'No todo!() left', check: (c) => !/todo!\s*\(\s*\)/.test(c) },
+      { name: 'solution_pattern', description: 'Code not empty', check: (c) => c.trim().length > 0 }
     ],
     starterCode: `// TODO: Implement Langton's Ant simulation
 //
@@ -10046,7 +10046,7 @@ mod tests {
 }
 `,
     hints: [
-      `💡 Regarde le README.md dans \`katas/03-advanced/02-langton-ant/\` pour les consignes.`
+      `💡 Check the README.md in \`katas/03-advanced/02-langton-ant/\` for the instructions.`
     ],
   },
   {
@@ -10107,8 +10107,8 @@ The SETUP, STARTER and STRUCTURE packages must have been completed
 Access to the Rust documentation at https://doc.rust-lang.org/std/index.html
 Access to the Rust book at https://doc.rust-lang.org/book/`,
     tests: [
-      { name: 'no_todo_remaining', description: 'Aucun todo!() restant', check: (c) => !/todo!\s*\(\s*\)/.test(c) },
-      { name: 'solution_pattern', description: 'Code non vide', check: (c) => c.trim().length > 0 }
+      { name: 'no_todo_remaining', description: 'No todo!() left', check: (c) => !/todo!\s*\(\s*\)/.test(c) },
+      { name: 'solution_pattern', description: 'Code not empty', check: (c) => c.trim().length > 0 }
     ],
     starterCode: `// TODO: Implement a Brainfuck interpreter
 //
@@ -10304,7 +10304,7 @@ mod tests {
 }
 `,
     hints: [
-      `💡 Regarde le README.md dans \`katas/03-advanced/03-brainfuck/\` pour les consignes.`
+      `💡 Check the README.md in \`katas/03-advanced/03-brainfuck/\` for the instructions.`
     ],
   },
   {
@@ -10358,8 +10358,8 @@ The SETUP, STARTER and STRUCTURE packages must have been completed
 Access to the Rust documentation at https://doc.rust-lang.org/std/index.html
 Access to the Rust book at https://doc.rust-lang.org/book/`,
     tests: [
-      { name: 'no_todo_remaining', description: 'Aucun todo!() restant', check: (c) => !/todo!\s*\(\s*\)/.test(c) },
-      { name: 'solution_pattern', description: 'Code non vide', check: (c) => c.trim().length > 0 }
+      { name: 'no_todo_remaining', description: 'No todo!() left', check: (c) => !/todo!\s*\(\s*\)/.test(c) },
+      { name: 'solution_pattern', description: 'Code not empty', check: (c) => c.trim().length > 0 }
     ],
     starterCode: `// TODO: Implement a Mathematical AST with Visitor pattern
 //
@@ -10574,7 +10574,7 @@ mod tests {
 }
 `,
     hints: [
-      `💡 Regarde le README.md dans \`katas/03-advanced/04-mathematical-ast/\` pour les consignes.`
+      `💡 Check the README.md in \`katas/03-advanced/04-mathematical-ast/\` for the instructions.`
     ],
   },
   {
@@ -10626,8 +10626,8 @@ The SETUP, STARTER and STRUCTURE packages must have been completed
 Access to the Rust documentation at https://doc.rust-lang.org/std/index.html
 Access to the Rust book at https://doc.rust-lang.org/book/`,
     tests: [
-      { name: 'no_todo_remaining', description: 'Aucun todo!() restant', check: (c) => !/todo!\s*\(\s*\)/.test(c) },
-      { name: 'solution_pattern', description: 'Code non vide', check: (c) => c.trim().length > 0 }
+      { name: 'no_todo_remaining', description: 'No todo!() left', check: (c) => !/todo!\s*\(\s*\)/.test(c) },
+      { name: 'solution_pattern', description: 'Code not empty', check: (c) => c.trim().length > 0 }
     ],
     starterCode: `// TODO: Implement concurrent Christmas Delivery
 //
@@ -10801,7 +10801,7 @@ mod tests {
 }
 `,
     hints: [
-      `💡 Regarde le README.md dans \`katas/03-advanced/05-christmas-delivery/\` pour les consignes.`
+      `💡 Check the README.md in \`katas/03-advanced/05-christmas-delivery/\` for the instructions.`
     ],
   },
 ]

--- a/academy/src/data/katas.json
+++ b/academy/src/data/katas.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-24T19:38:01.537Z",
+  "generatedAt": "2026-08-07T07:24:57.740Z",
   "count": 36,
   "katas": [
     {
@@ -301,7 +301,7 @@
       "package": "nim-game",
       "level": "starter",
       "difficulty": "beginner",
-      "readme": "# NimGame\n\nKata for the STARTER package of the Rust coding DOJO\n\n## Level / Duration\n\nBeginner / 30 minutes\n\nThis kata as a part of the STARTER package targets Rust beginners.\n\n## Context\nThis kata is based on [Nim from Coding Dojo](https://codingdojo.org/kata/Nim/).\n\nJeu de Nim à deux joueurs. Start with a pile of sticks. Each turn, a player removes 1, 2, or 3 sticks. The player who takes the **last** stick **loses**.\n\nGiven an initial number of sticks, determine which player wins with optimal play.\n\n## Objective\nImplement `nim_winner(sticks: u32) -> &'static str` that returns `\"Player 1\"` or `\"Player 2\"` (the winner with optimal play).\n\n**Hint:** Think about multiples of 4 — positions that are losing for the current player follow a pattern.\n\n## Domains\n\n`Basics` `Pattern Matching` `Algorithms` `Game Theory`\n\n## How to run a kata\nAll katas share the same structure:\n```\n/XX-package/XX-kataname\n|- src\n|   main.rs\n|- solutions\n|   main.rs\nCargo.lock\nCargo.toml\n```\n\nRun the exercise:\n```bash\ncargo run\ncargo test\n```\n\nRun the solution:\n```bash\ncargo run --bin solutions\n```\n\n## Prerequisites\nThe SETUP package must have been completed\n\nAccess to the Rust documentation at https://doc.rust-lang.org/std/index.html\nAccess to the Rust book at https://doc.rust-lang.org/book/\n",
+      "readme": "# NimGame\n\nKata for the STARTER package of the Rust coding DOJO\n\n## Level / Duration\n\nBeginner / 30 minutes\n\nThis kata as a part of the STARTER package targets Rust beginners.\n\n## Context\nThis kata is based on [Nim from Coding Dojo](https://codingdojo.org/kata/Nim/).\n\nTwo-player Nim game. Start with a pile of sticks. Each turn, a player removes 1, 2, or 3 sticks. The player who takes the **last** stick **loses**.\n\nGiven an initial number of sticks, determine which player wins with optimal play.\n\n## Objective\nImplement `nim_winner(sticks: u32) -> &'static str` that returns `\"Player 1\"` or `\"Player 2\"` (the winner with optimal play).\n\n**Hint:** Think about multiples of 4 — positions that are losing for the current player follow a pattern.\n\n## Domains\n\n`Basics` `Pattern Matching` `Algorithms` `Game Theory`\n\n## How to run a kata\nAll katas share the same structure:\n```\n/XX-package/XX-kataname\n|- src\n|   main.rs\n|- solutions\n|   main.rs\nCargo.lock\nCargo.toml\n```\n\nRun the exercise:\n```bash\ncargo run\ncargo test\n```\n\nRun the solution:\n```bash\ncargo run --bin solutions\n```\n\n## Prerequisites\nThe SETUP package must have been completed\n\nAccess to the Rust documentation at https://doc.rust-lang.org/std/index.html\nAccess to the Rust book at https://doc.rust-lang.org/book/\n",
       "exercises": [
         {
           "name": "main.rs",

--- a/academy/src/llm/localWllama.ts
+++ b/academy/src/llm/localWllama.ts
@@ -162,24 +162,24 @@ function ensureModelLoaded() {
 }
 
 function buildPrompt(userMessage: string, context: FerrisContext) {
-  return `Contexte du kata :
+  return `Kata context:
 
-Titre : ${context.kataTitle}
-Concept : ${context.kataConcept ?? 'non renseigné'}
-Difficulté : ${context.kataDifficulty ?? 'non renseignée'}
+Title: ${context.kataTitle}
+Concept: ${context.kataConcept ?? 'not specified'}
+Difficulty: ${context.kataDifficulty ?? 'not specified'}
 
-Code actuel :
+Current code:
 \`\`\`rust
 ${context.code}
 \`\`\`
 
-Résultats des tests :
+Test results:
 ${formatTests(context.tests ?? [])}
 
-Sortie d'exécution :
+Execution output:
 ${formatOutput(context.output ?? [])}
 
-Question de l'apprenant :
+Learner's question:
 ${userMessage}`
 }
 
@@ -194,12 +194,12 @@ function buildRecentHistory(history: ChatMessage[]) {
 }
 
 function formatTests(tests: Array<{ name: string; pass: boolean }>) {
-  if (tests.length === 0) return 'Les tests n’ont pas encore été lancés.'
+  if (tests.length === 0) return 'Tests have not been run yet.'
   return tests.map((test) => `${test.pass ? 'PASS' : 'FAIL'} ${test.name}`).join('\n')
 }
 
 function formatOutput(output: Array<{ text: string }>) {
-  if (output.length === 0) return 'Aucune sortie disponible.'
+  if (output.length === 0) return 'No output available.'
   return output.map((line) => line.text).join('\n')
 }
 

--- a/academy/src/screens/GraalScreen.tsx
+++ b/academy/src/screens/GraalScreen.tsx
@@ -68,7 +68,7 @@ export function GraalScreen() {
     <div className="graal-screen graal-screen--locked">
       <div className="graal-content" style={{ textAlign: 'center' }}>
         <div style={{ fontFamily: 'JetBrains Mono', fontSize: 11, color: '#ffd08a', letterSpacing: '0.28em', textTransform: 'uppercase' }}>
-          La quête finale
+          The final quest
         </div>
 
         <div className="graal-mystery-box">

--- a/academy/src/screens/KataScreen.tsx
+++ b/academy/src/screens/KataScreen.tsx
@@ -267,7 +267,7 @@ export function KataScreen() {
     outputLines.push({ text: '', color: '#4a6080' })
 
     if (solExecuted) {
-      const matchLabel = stdoutMatch ? '✓ identique' : '✗ différent'
+      const matchLabel = stdoutMatch ? '✓ identical' : '✗ different'
       const matchColor = stdoutMatch ? '#8af0c0' : '#ff8a5c'
       outputLines.push({ text: `   Output vs solution: ${matchLabel}`, color: matchColor })
     } else if (kata.solutionCode && kata.solutionCode.trim()) {
@@ -278,10 +278,10 @@ export function KataScreen() {
     setOutput(outputLines)
 
     const msg: ChatMessage = allPass
-      ? { role: 'ferris', text: `🎉 Les ${newTests.length} tests passent et la sortie correspond à la solution ! +${kata.xpReward} XP !`, timestamp: Date.now() }
+      ? { role: 'ferris', text: `🎉 All ${newTests.length} tests pass and the output matches the solution! +${kata.xpReward} XP!`, timestamp: Date.now() }
       : stdoutMatch
-        ? { role: 'ferris', text: `Pas encore — ${newTests.filter(t => !t.pass).map(t => t.name).join(', ')} échoue(nt). Clique 💡 Indice +1 si tu bloques.`, timestamp: Date.now() }
-        : { role: 'ferris', text: `La sortie de ton code ne correspond pas à la solution attendue. Vérifie les println!().`, timestamp: Date.now() }
+      ? { role: 'ferris', text: `Not yet — ${newTests.filter(t => !t.pass).map(t => t.name).join(', ')} failing. Click 💡 Hint +1 if you're stuck.`, timestamp: Date.now() }
+      : { role: 'ferris', text: `Your code's output doesn't match the expected solution. Check your println!() calls.`, timestamp: Date.now() }
 
     setChat(prev => [...prev, msg])
 

--- a/academy/src/screens/PathScreen.tsx
+++ b/academy/src/screens/PathScreen.tsx
@@ -116,7 +116,7 @@ export function PathScreen() {
               <div className="path-graal-title">At the end of the path… a surprise awaits 🤫</div>
               <div className="path-graal-desc">A legendary reward, sealed until the final challenge. No one knows what it is until it's unlocked.</div>
             </div>
-            <span className="btn btn--golden" style={{ padding: '9px 14px', fontSize: 11, whiteSpace: 'nowrap' }}>Voir la quête →</span>
+            <span className="btn btn--golden" style={{ padding: '9px 14px', fontSize: 11, whiteSpace: 'nowrap' }}>View the quest →</span>
           </button>
         )}
       </div>

--- a/academy/tools/generate-katas.cjs
+++ b/academy/tools/generate-katas.cjs
@@ -148,13 +148,13 @@ for (const { full, rel } of kataDirs) {
   const solutionsDir = path.join(full, 'solutions')
   let solutionCode = readRustFiles(solutionsDir) || ''
 
-  const desc = readme.trim() || `Consulte le README.md du kata dans le dossier \`katas/${rel}/\``
+  const desc = readme.trim() || `See the kata's README.md in the \`katas/${rel}/\` folder`
 
   const tests = []
   if (starterCode.includes('todo!()') || starterCode.includes('todo!')) {
-    tests.push({ name: 'no_todo_remaining', description: 'Aucun todo!() restant', check: '(c) => !/todo!\\s*\\(\\s*\\)/.test(c)' })
+    tests.push({ name: 'no_todo_remaining', description: 'No todo!() left', check: '(c) => !/todo!\\s*\\(\\s*\\)/.test(c)' })
   }
-  tests.push({ name: 'solution_pattern', description: 'Code non vide', check: '(c) => c.trim().length > 0' })
+  tests.push({ name: 'solution_pattern', description: 'Code not empty', check: '(c) => c.trim().length > 0' })
 
   const testsJson = tests.map(t =>
     `      { name: '${t.name}', description: '${t.description}', check: ${t.check} }`
@@ -183,10 +183,10 @@ for (const { full, rel } of kataDirs) {
   function escHint(s) {
     return s.replace(/\\/g, '\\\\').replace(/`/g, '\\`').replace(/\${/g, '\\${')
   }
-  const hint1 = escHint(`💡 Regarde le README.md dans \`katas/${rel}/\` pour les consignes.`)
-  const hint2 = escHint(`💡 Consulte la solution dans \`katas/${rel}/solutions/\` si tu bloques.`)
-  const hint3 = escHint(`💡 Ce kata n\u00e9cessite de comprendre les concepts avanc\u00e9s \u2014 relis le README.md.`)
-  const hint4 = escHint(`💡 Les fichiers solutions dans \`katas/${rel}/solutions/\` contiennent la correction.`)
+  const hint1 = escHint(`💡 Check the README.md in \`katas/${rel}/\` for the instructions.`)
+  const hint2 = escHint(`💡 Check the solution in \`katas/${rel}/solutions/\` if you're stuck.`)
+  const hint3 = escHint(`💡 This kata requires understanding advanced concepts \u2014 re-read the README.md.`)
+  const hint4 = escHint(`💡 The solution files in \`katas/${rel}/solutions/\` contain the fix.`)
   if (parsed.isBeginner) {
     lines.push(`      \`${hint1}\`,`)
     lines.push(`      \`${hint2}\``)

--- a/katas/01-starter/10-nim-game/README.md
+++ b/katas/01-starter/10-nim-game/README.md
@@ -11,7 +11,7 @@ This kata as a part of the STARTER package targets Rust beginners.
 ## Context
 This kata is based on [Nim from Coding Dojo](https://codingdojo.org/kata/Nim/).
 
-Jeu de Nim à deux joueurs. Start with a pile of sticks. Each turn, a player removes 1, 2, or 3 sticks. The player who takes the **last** stick **loses**.
+Two-player Nim game. Start with a pile of sticks. Each turn, a player removes 1, 2, or 3 sticks. The player who takes the **last** stick **loses**.
 
 Given an initial number of sticks, determine which player wins with optimal play.
 


### PR DESCRIPTION
## Summary
Fixes leftover French UI text that made it through the earlier translation pass.

## Changes
- academy/src/data/gamification.ts: translated badges, quests, skill tree node names/descriptions, and Graal chapter labels
- academy/src/screens/KataScreen.tsx: translated Ferris chat feedback messages shown after running tests
- academy/src/screens/GraalScreen.tsx / PathScreen.tsx: translated remaining UI labels ("La quête finale", "Voir la quête")
- academy/src/llm/localWllama.ts: translated the local wllama LLM prompt template
- katas/01-starter/10-nim-game/README.md: translated a leftover FR sentence in the kata description
- academy/tools/generate-katas.cjs: translated hardcoded hint/test-description strings baked into generated kata data, then regenerated katas.generated.ts (actual data source used by the app) and katas.json

## Validation
- `npm run build` (tsc + vite build) passes
- `npx tsc --noEmit` passes
- Verified diffs are text-only: line-by-line comparison of `katas.generated.ts` shows exactly 135 differing lines, all inside string literals (ids, checks, and object structure untouched)
